### PR TITLE
feat: Add F9 hotkey to pause and resume audio capture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,7 @@ dependencies = [
  "rubato",
  "tokio",
  "wasapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1125,11 +1126,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1143,19 +1153,35 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -1169,9 +1195,21 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1181,9 +1219,21 @@ checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -1193,9 +1243,21 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1205,9 +1267,21 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,7 @@ hound = "3.5"
 ringbuf = "0.4"
 rubato = "0.16"
 ort = { version = "2.0.0-rc.12", features = ["download-binaries"] }
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = [
+    "Win32_UI_Input_KeyboardAndMouse",
+] }

--- a/src/audio/hotkey.rs
+++ b/src/audio/hotkey.rs
@@ -1,0 +1,39 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+use windows_sys::Win32::UI::Input::KeyboardAndMouse::{GetAsyncKeyState, VK_F9};
+use std::time::Duration;
+use std::thread;
+
+pub type PauseFlag = Arc<AtomicBool>;
+
+pub fn new_pause_flag() -> PauseFlag {
+    Arc::new(AtomicBool::new(false))
+}
+
+pub fn spawn_hotkey_listener(flag: PauseFlag) {
+    thread::Builder::new()
+        .name("hotkey-listener".into())
+        .spawn(move || run_hotkey_loop(flag))
+        .expect("failed to spawn hotkey listener thread");
+}
+
+fn run_hotkey_loop(flag: PauseFlag) {
+    println!("[hotkey] F9 activo — presioná para pausar / reanudar");
+
+    let mut was_pressed = false;
+
+    loop {
+        let is_pressed = unsafe { GetAsyncKeyState(VK_F9 as i32) } < 0;
+
+        if is_pressed && !was_pressed {
+            let was_paused = flag.fetch_xor(true, Ordering::Relaxed);
+            let label = if was_paused { "resumed ▶" } else { "paused  ⏸" };
+            println!("[hotkey] Capture {label}");
+        }
+
+        was_pressed = is_pressed;
+        thread::sleep(Duration::from_millis(30));
+    }
+}

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -1,4 +1,5 @@
 pub mod resampler;
+pub mod hotkey;
 pub mod vad;
 pub mod wasapi;
 pub mod wav_writer;

--- a/src/audio/wasapi.rs
+++ b/src/audio/wasapi.rs
@@ -3,7 +3,9 @@ use tokio::sync::mpsc;
 use std::thread;
 use wasapi;
 use ringbuf::{HeapRb, traits::{Producer, Consumer, Split}};
+use std::sync::atomic::Ordering;
 
+use crate::audio::hotkey::PauseFlag;
 use crate::config;
 use super::{AudioEvent, AudioFormat, Speaker};
 use super::resampler::Resampler;
@@ -37,14 +39,14 @@ struct OpenDevice {
 }
 
 
-pub fn start_concurrent_capture(tx: mpsc::Sender<AudioEvent>) -> Result<()> {
-    spawn_capture_pipeline(AudioSource::Microphone,     tx.clone());
-    spawn_capture_pipeline(AudioSource::SystemLoopback, tx);
+pub fn start_concurrent_capture(tx: mpsc::Sender<AudioEvent>, pause_flag: PauseFlag) -> Result<()> {
+    spawn_capture_pipeline(AudioSource::Microphone, tx.clone(), pause_flag.clone());
+    spawn_capture_pipeline(AudioSource::SystemLoopback, tx, pause_flag);
     Ok(())
 }
 
 
-fn spawn_capture_pipeline(source: AudioSource, tx: mpsc::Sender<AudioEvent>) {
+fn spawn_capture_pipeline(source: AudioSource, tx: mpsc::Sender<AudioEvent>, pause_flag: PauseFlag,) {
     let ring = HeapRb::<f32>::new(config::capture::RING_BUFFER_CAPACITY);
     let (mut ring_producer, ring_consumer) = ring.split();
     let speaker   = source.speaker();
@@ -62,7 +64,7 @@ fn spawn_capture_pipeline(source: AudioSource, tx: mpsc::Sender<AudioEvent>) {
 
     thread::spawn(move || {
         let _ = wasapi::initialize_mta();
-        if let Err(e) = forward_normalized_audio(ring_consumer, speaker, device.format, tx) {
+        if let Err(e) = forward_normalized_audio(ring_consumer, speaker, device.format, pause_flag, tx,) {
             eprintln!("[wasapi] {speaker} forwarding error: {e:?}");
         }
     });
@@ -89,6 +91,7 @@ fn forward_normalized_audio(
     mut consumer: impl Consumer<Item = f32>,
     speaker:      Speaker,
     format:       AudioFormat,
+    pause_flag:   PauseFlag,
     tx:           mpsc::Sender<AudioEvent>,
 ) -> Result<()> {
     let mut resampler = Resampler::new(format.sample_rate as f64)?;
@@ -99,6 +102,10 @@ fn forward_normalized_audio(
 
         if samples_read == 0 {
             std::thread::sleep(std::time::Duration::from_millis(1));
+            continue;
+        }
+
+        if pause_flag.load(Ordering::Relaxed) {
             continue;
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,14 +10,18 @@ use anyhow::Result;
 use audio::{AudioEvent, Speaker};
 use audio::vad::{SpeechTurn, VadChannel};
 use audio::wav_writer::{CaptureRecorder, save_turn_as_wav};
+use audio::hotkey;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     println!("AI Interview Copilot starting…");
 
+    let pause_flag = hotkey::new_pause_flag();
+    hotkey::spawn_hotkey_listener(pause_flag.clone());  
+
     let (audio_tx, audio_rx) = mpsc::channel::<AudioEvent>(1_000);
 
-    audio::wasapi::start_concurrent_capture(audio_tx)?;
+    audio::wasapi::start_concurrent_capture(audio_tx, pause_flag)?;
 
     tokio::spawn(process_audio_stream(audio_rx));
 


### PR DESCRIPTION
Introduces a new hotkey.rs module with a dedicated background thread that polls GetAsyncKeyState to toggle a shared AtomicBool flag. The capture pipeline in wasapi.rs reads this flag and discards samples while paused, keeping both the WASAPI and ring buffers drained to prevent overflow.