### PR TITLE
Refactor: decouple normalization logic from WASAPI transport layer.

### DIFF
--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -1,5 +1,7 @@
 pub mod resampler;
 pub mod hotkey;
+pub mod normalizer;
+pub mod pipeline;
 pub mod vad;
 pub mod wasapi;
 pub mod wav_writer;
@@ -47,10 +49,6 @@ pub enum AudioEvent {
         speaker: Speaker,
         samples: Vec<f32>,
         format:  AudioFormat,
-    },
-    NormalizedCapture {
-        speaker: Speaker,
-        samples: Vec<i16>,
     },
     CaptureError {
         speaker: Speaker,

--- a/src/audio/normalizer.rs
+++ b/src/audio/normalizer.rs
@@ -1,0 +1,24 @@
+use anyhow::Result;
+
+use crate::audio::{AudioFormat};
+use crate::audio::resampler::Resampler;
+
+pub struct AudioNormalizer {
+    resampler: Option<Resampler>,
+}
+
+impl AudioNormalizer {
+    pub fn new() -> Self {
+        Self { resampler: None }
+    }
+
+    pub fn process(&mut self, samples: &[f32], format: AudioFormat) -> Result<Vec<i16>> {
+        let resampler = self.resampler.get_or_insert_with(|| {
+            Resampler::new(format.sample_rate as f64)
+                .expect("failed to create resampler")
+        });
+
+        let mono = Resampler::downmix_to_mono(samples, format.channels as usize);
+        resampler.resample(&mono)
+    }
+}

--- a/src/audio/pipeline.rs
+++ b/src/audio/pipeline.rs
@@ -1,0 +1,70 @@
+use tokio::sync::mpsc;
+use std::sync::atomic::Ordering;
+
+use crate::audio::{AudioEvent, Speaker};
+use crate::audio::hotkey::PauseFlag;
+use crate::audio::vad::{SpeechTurn, VadChannel};
+use crate::audio::wav_writer::{CaptureRecorder, save_turn_as_wav};
+use super::normalizer::AudioNormalizer;
+
+pub async fn run(mut rx: mpsc::Receiver<AudioEvent>, pause_flag: PauseFlag) {
+    let mut user_vad   = VadChannel::new(Speaker::User)
+        .expect("failed to initialise user VAD channel");
+    let mut system_vad = VadChannel::new(Speaker::System)
+        .expect("failed to initialise system VAD channel");
+
+    let mut user_normalizer   = AudioNormalizer::new();
+    let mut system_normalizer = AudioNormalizer::new();
+
+    let mut recorder    = CaptureRecorder::new();
+    let mut conversation: Vec<SpeechTurn> = Vec::new();
+
+    while let Some(event) = rx.recv().await {
+
+        if pause_flag.load(Ordering::Relaxed) {
+            continue;
+        }
+
+        match event {
+            AudioEvent::RawCapture { speaker, samples, format } => {
+                recorder.record_chunk(speaker, &samples, format);
+
+                let normalizer = match speaker {
+                    Speaker::User   => &mut user_normalizer,
+                    Speaker::System => &mut system_normalizer,
+                };
+
+                match normalizer.process(&samples, format) {
+                    Ok(normalized) if !normalized.is_empty() => {
+                        let new_turns = match speaker {
+                            Speaker::User   => user_vad.push(&normalized),
+                            Speaker::System => system_vad.push(&normalized),
+                        };
+                        for turn in new_turns {
+                            on_turn_completed(&turn);
+                            insert_chronologically(&mut conversation, turn);
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(e) => eprintln!("[normalizer] {speaker} error: {e}"),
+                }
+            }
+
+            AudioEvent::CaptureError { speaker, error } => {
+                eprintln!("[audio] {speaker} capture error: {error}");
+            }
+        }
+    }
+}
+
+fn on_turn_completed(turn: &SpeechTurn) {
+    println!("[TURN] {turn}");
+    if let Err(e) = save_turn_as_wav(turn.speaker, turn.start_ms, &turn.audio) {
+        eprintln!("[wav] Failed to save turn: {e}");
+    }
+}
+
+fn insert_chronologically(conversation: &mut Vec<SpeechTurn>, turn: SpeechTurn) {
+    let pos = conversation.partition_point(|t| t.start_ms <= turn.start_ms);
+    conversation.insert(pos, turn);
+}

--- a/src/audio/wasapi.rs
+++ b/src/audio/wasapi.rs
@@ -3,12 +3,9 @@ use tokio::sync::mpsc;
 use std::thread;
 use wasapi;
 use ringbuf::{HeapRb, traits::{Producer, Consumer, Split}};
-use std::sync::atomic::Ordering;
 
-use crate::audio::hotkey::PauseFlag;
 use crate::config;
 use super::{AudioEvent, AudioFormat, Speaker};
-use super::resampler::Resampler;
 
 enum AudioSource {
     Microphone,
@@ -38,15 +35,19 @@ struct OpenDevice {
     format:         AudioFormat,
 }
 
+struct SendableDevice(OpenDevice);
+unsafe impl Send for SendableDevice {}
+unsafe impl Sync for SendableDevice {}
 
-pub fn start_concurrent_capture(tx: mpsc::Sender<AudioEvent>, pause_flag: PauseFlag) -> Result<()> {
-    spawn_capture_pipeline(AudioSource::Microphone, tx.clone(), pause_flag.clone());
-    spawn_capture_pipeline(AudioSource::SystemLoopback, tx, pause_flag);
+
+pub fn start_concurrent_capture(tx: mpsc::Sender<AudioEvent>) -> Result<()> {
+    spawn_capture_pipeline(AudioSource::Microphone, tx.clone());
+    spawn_capture_pipeline(AudioSource::SystemLoopback, tx);
     Ok(())
 }
 
 
-fn spawn_capture_pipeline(source: AudioSource, tx: mpsc::Sender<AudioEvent>, pause_flag: PauseFlag,) {
+fn spawn_capture_pipeline(source: AudioSource, tx: mpsc::Sender<AudioEvent>) {
     let ring = HeapRb::<f32>::new(config::capture::RING_BUFFER_CAPACITY);
     let (mut ring_producer, ring_consumer) = ring.split();
     let speaker   = source.speaker();
@@ -54,17 +55,19 @@ fn spawn_capture_pipeline(source: AudioSource, tx: mpsc::Sender<AudioEvent>, pau
 
     let _ = wasapi::initialize_mta();
     let device = open_device(&direction).expect("Open device error");
+    let format = device.format;
+    let sendable_device = SendableDevice(device);
 
     thread::spawn(move || {
         let _ = wasapi::initialize_mta();
-        if let Err(e) = fill_ring_buffer(direction, speaker, &mut ring_producer) {
+        if let Err(e) = fill_ring_buffer(sendable_device, speaker, &mut ring_producer) {
             eprintln!("[wasapi] {speaker} capture error: {e:?}");
         }
     });
 
     thread::spawn(move || {
         let _ = wasapi::initialize_mta();
-        if let Err(e) = forward_normalized_audio(ring_consumer, speaker, device.format, pause_flag, tx,) {
+        if let Err(e) = forward_raw_audio(ring_consumer, speaker, format, tx,) {
             eprintln!("[wasapi] {speaker} forwarding error: {e:?}");
         }
     });
@@ -72,60 +75,41 @@ fn spawn_capture_pipeline(source: AudioSource, tx: mpsc::Sender<AudioEvent>, pau
 
 
 fn fill_ring_buffer(
-    direction: wasapi::Direction,
+    device:   SendableDevice,
     speaker:   Speaker,
     producer:  &mut impl Producer<Item = f32>,
 ) -> Result<()> {
-    let device = open_device(&direction)?;
-
-    println!("[wasapi] {speaker} capture started — {}", device.format);
+    println!("[wasapi] {speaker} capture started — {}", device.0.format);
 
     loop {
-        device.event_handle.wait_for_event(config::capture::EVENT_TIMEOUT_MS)?;
-        drain_device_buffer(&device.capture_client, device.format.channels as usize, producer)?;
+        device.0.event_handle.wait_for_event(config::capture::EVENT_TIMEOUT_MS)?;
+        drain_device_buffer(&device.0.capture_client, device.0.format.channels as usize, producer)?;
     }
 }
 
 
-fn forward_normalized_audio(
+fn forward_raw_audio(
     mut consumer: impl Consumer<Item = f32>,
     speaker:      Speaker,
     format:       AudioFormat,
-    pause_flag:   PauseFlag,
     tx:           mpsc::Sender<AudioEvent>,
 ) -> Result<()> {
-    let mut resampler = Resampler::new(format.sample_rate as f64)?;
-    let mut chunk     = vec![0f32; config::capture::CONSUMER_CHUNK_SIZE];
+    let mut chunk = vec![0f32; config::capture::CONSUMER_CHUNK_SIZE];
 
     loop {
-        let samples_read = consumer.pop_slice(&mut chunk);
+        let n = consumer.pop_slice(&mut chunk);
 
-        if samples_read == 0 {
+        if n == 0 {
             std::thread::sleep(std::time::Duration::from_millis(1));
             continue;
         }
 
-        if pause_flag.load(Ordering::Relaxed) {
-            continue;
-        }
-
-        let raw = &chunk[..samples_read];
-
         tx.blocking_send(AudioEvent::RawCapture {
             speaker,
-            samples: raw.to_vec(),
+            samples: chunk[..n].to_vec(),
             format,
-        }).map_err(|_| anyhow::anyhow!("audio channel closed"))?;
-
-        let mono      = Resampler::downmix_to_mono(raw, format.channels as usize);
-        let resampled = resampler.resample(&mono)?;
-
-        if !resampled.is_empty() {
-            tx.blocking_send(AudioEvent::NormalizedCapture {
-                speaker,
-                samples: resampled,
-            }).map_err(|_| anyhow::anyhow!("audio channel closed"))?;
-        }
+        })
+        .map_err(|_| anyhow::anyhow!("audio channel closed"))?;
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,7 @@ mod ui;
 use tokio::sync::mpsc;
 use anyhow::Result;
 
-use audio::{AudioEvent, Speaker};
-use audio::vad::{SpeechTurn, VadChannel};
-use audio::wav_writer::{CaptureRecorder, save_turn_as_wav};
+use audio::AudioEvent;
 use audio::hotkey;
 
 #[tokio::main]
@@ -17,61 +15,14 @@ async fn main() -> Result<()> {
     println!("AI Interview Copilot starting…");
 
     let pause_flag = hotkey::new_pause_flag();
-    hotkey::spawn_hotkey_listener(pause_flag.clone());  
+    hotkey::spawn_hotkey_listener(pause_flag.clone());
 
     let (audio_tx, audio_rx) = mpsc::channel::<AudioEvent>(1_000);
 
-    audio::wasapi::start_concurrent_capture(audio_tx, pause_flag)?;
-
-    tokio::spawn(process_audio_stream(audio_rx));
+    audio::wasapi::start_concurrent_capture(audio_tx)?;
+    tokio::spawn(audio::pipeline::run(audio_rx, pause_flag));
 
     tokio::signal::ctrl_c().await?;
     println!("Shutting down…");
     Ok(())
-}
-
-async fn process_audio_stream(mut rx: mpsc::Receiver<AudioEvent>) {
-    let mut user_vad = VadChannel::new(Speaker::User)
-        .expect("failed to initialise user (microphone) VAD channel");
-    let mut system_vad = VadChannel::new(Speaker::System)
-        .expect("failed to initialise system (loopback) VAD channel");
-
-    let mut recorder     = CaptureRecorder::new();
-    let mut conversation: Vec<SpeechTurn> = Vec::new();
-
-    while let Some(event) = rx.recv().await {
-        match event {
-            AudioEvent::RawCapture { speaker, samples, format } => {
-                recorder.record_chunk(speaker, &samples, format);
-            }
-
-            AudioEvent::NormalizedCapture { speaker, samples } => {
-                let new_turns = match speaker {
-                    Speaker::User   => user_vad.push(&samples),
-                    Speaker::System => system_vad.push(&samples),
-                };
-
-                for turn in new_turns {
-                    on_turn_completed(&turn);
-                    insert_chronologically(&mut conversation, turn);
-                }
-            }
-
-            AudioEvent::CaptureError { speaker, error } => {
-                eprintln!("[audio] {speaker} capture error: {error}");
-            }
-        }
-    }
-}
-
-fn on_turn_completed(turn: &SpeechTurn) {
-    println!("[TURN] {turn}");
-    if let Err(e) = save_turn_as_wav(turn.speaker, turn.start_ms, &turn.audio) {
-        eprintln!("[wav] Failed to save turn: {e}");
-    }
-}
-
-fn insert_chronologically(conversation: &mut Vec<SpeechTurn>, turn: SpeechTurn) {
-    let pos = conversation.partition_point(|t| t.start_ms <= turn.start_ms);
-    conversation.insert(pos, turn);
 }


### PR DESCRIPTION
wasapi.rs now only handles hardware capture and emits RawCapture events. Downmix and resampling were moved out of the capture threads into a new AudioNormalizer struct in audio/normalizer.rs. The audio event loop was extracted into audio/pipeline.rs, which is also where the pause flag is now checked — removing that responsibility from the transport layer. The NormalizedCapture event variant was deleted. A bug was also fixed where two WASAPI devices were being opened per source: one for reading the format, one for actual capture. Now a single device is opened and its ownership is moved into the capture thread.